### PR TITLE
Correct version bounds to avoid compile failure

### DIFF
--- a/pretty-simple.cabal
+++ b/pretty-simple.cabal
@@ -27,7 +27,7 @@ library
                      , Text.Pretty.Simple.Internal.ExprToOutput
                      , Text.Pretty.Simple.Internal.Output
                      , Text.Pretty.Simple.Internal.OutputPrinter
-  build-depends:       base >= 4.6 && < 5
+  build-depends:       base >= 4.8 && < 5
                      , ansi-terminal
                      , containers
                      , lens

--- a/stack.yaml
+++ b/stack.yaml
@@ -33,3 +33,7 @@ extra-package-dbs: []
 
 # Allow a newer minor version of GHC than the snapshot specifies
 # compiler-check: newer-minor
+
+# Enable Hackage-friendly mode, for more details see
+#  https://docs.haskellstack.org/en/stable/yaml_configuration/#pvp-bounds
+pvp-bounds: both


### PR DESCRIPTION
This avoids cabal running into the compile failure below:

```
Configuring component lib from pretty-simple-1.0.0.3...
Preprocessing library pretty-simple-1.0.0.3...
[1 of 7] Compiling Text.Pretty.Simple.Internal.Output ( src/Text/Pretty/Simple/Internal/Output.hs, /tmp/matrix-worker/1484457210/dist-newstyle/build/x86_64-linux/ghc-7.8.4/pretty-simple-1.0.0.3/build/Text/Pretty/Simple/Internal/Output.o )
Loading package ghc-prim ... linking ... done.
Loading package integer-gmp ... linking ... done.
Loading package base ... linking ... done.
Loading package array-0.5.0.0 ... linking ... done.
Loading package deepseq-1.3.0.2 ... linking ... done.
Loading package bytestring-0.10.4.0 ... linking ... done.
Loading package transformers-0.3.0.0 ... linking ... done.
Loading package mtl-2.1.3.1 ... linking ... done.
Loading package containers-0.5.5.1 ... linking ... done.
Loading package binary-0.7.1.0 ... linking ... done.
Loading package text-1.2.2.1 ... linking ... done.
Loading package parsec-3.1.11 ... linking ... done.
Loading package hashable-1.2.5.0 ... linking ... done.
Loading package pretty-1.1.1.1 ... linking ... done.
Loading package template-haskell ... linking ... done.
Loading package nats-1.1.1 ... linking ... done.
Loading package transformers-compat-0.5.1.3 ... linking ... done.
Loading package tagged-0.8.5 ... linking ... done.
Loading package unordered-containers-0.2.7.2 ... linking ... done.
Loading package semigroups-0.18.2 ... linking ... done.
Loading package split-0.2.3.1 ... linking ... done.
Loading package primitive-0.6.2.0 ... linking ... done.
Loading package vector-0.12.0.0 ... linking ... done.
Loading package vector-algorithms-0.7.0.1 ... linking ... done.
Loading package mono-traversable-1.0.1 ... linking ... done.
Loading package base-orphans-0.5.4 ... linking ... done.
Loading package stm-2.4.4.1 ... linking ... done.
Loading package StateVar-1.1.0.4 ... linking ... done.
Loading package void-0.7.1 ... linking ... done.
Loading package contravariant-1.4 ... linking ... done.
Loading package distributive-0.5.1 ... linking ... done.
Loading package comonad-5 ... linking ... done.
Loading package bifunctors-5.4.1 ... linking ... done.
Loading package exceptions-0.8.3 ... linking ... done.
Loading package filepath-1.3.0.2 ... linking ... done.
Loading package prelude-extras-0.4.0.3 ... linking ... done.
Loading package profunctors-5.2 ... linking ... done.
Loading package semigroupoids-5.1 ... linking ... done.
Loading package free-4.12.4 ... linking ... done.
Loading package generic-deriving-1.11.1 ... linking ... done.
Loading package adjunctions-4.3 ... linking ... done.
Loading package kan-extensions-5.0.1 ... linking ... done.
Loading package parallel-3.2.1.0 ... linking ... done.
Loading package reflection-2.1.2 ... linking ... done.
Loading package lens-4.15.1 ... linking ... done.
Loading package old-locale-1.0.0.6 ... linking ... done.
Loading package time-1.4.2 ... linking ... done.
Loading package unix-2.7.0.1 ... linking ... done.
Loading package ansi-terminal-0.6.2.3 ... linking ... done.

src/Text/Pretty/Simple/Internal/Output.hs:27:1: Warning:
    The import of ‘Control.Applicative’ is redundant
      except perhaps to import instances from ‘Control.Applicative’
    To import instances alone, use: import Control.Applicative()
[2 of 7] Compiling Text.Pretty.Simple.Internal.OutputPrinter ( src/Text/Pretty/Simple/Internal/OutputPrinter.hs, /tmp/matrix-worker/1484457210/dist-newstyle/build/x86_64-linux/ghc-7.8.4/pretty-simple-1.0.0.3/build/Text/Pretty/Simple/Internal/OutputPrinter.o )

src/Text/Pretty/Simple/Internal/OutputPrinter.hs:78:29:
    Not in scope: ‘mappend’

src/Text/Pretty/Simple/Internal/OutputPrinter.hs:93:12:
    Not in scope: ‘mconcat’
    Perhaps you meant ‘concat’ (imported from Prelude)

src/Text/Pretty/Simple/Internal/OutputPrinter.hs:113:27:
    Not in scope: type constructor or class ‘Monoid’
    Perhaps you meant ‘Monad’ (imported from Prelude)

src/Text/Pretty/Simple/Internal/OutputPrinter.hs:113:37:
    Not in scope: type constructor or class ‘Traversable’

src/Text/Pretty/Simple/Internal/OutputPrinter.hs:242:30:
    Not in scope: ‘mappend’
```