### PR TITLE
Allow light-bg and no-color modes for executable

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -29,7 +29,7 @@ import qualified Data.Text.Lazy.IO as LT
 import Options.Applicative 
        ( Parser, ReadM, execParser, fullDesc, help, helper, info, long
        , option, progDesc, readerError, short, showDefaultWith, str, value, (<**>))
-import Data.Semigroup ((<>))
+import Data.Monoid ((<>))
 import Text.Pretty.Simple 
        ( pStringOpt, OutputOptions
        , defaultOutputOptionsDarkBg

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -26,10 +26,55 @@ module Main where
 import Data.Text (unpack)
 import qualified Data.Text.IO as T
 import qualified Data.Text.Lazy.IO as LT
-import Text.Pretty.Simple (pString)
+import Options.Applicative 
+       ( Parser, ReadM, execParser, fullDesc, help, helper, info, long
+       , maybeReader, option, progDesc, short, showDefaultWith, value, (<**>))
+import Data.Semigroup ((<>))
+import Text.Pretty.Simple 
+       ( pStringOpt, OutputOptions
+       , defaultOutputOptionsDarkBg
+       , defaultOutputOptionsLightBg
+       , defaultOutputOptionsNoColor
+       )
+
+data Color = DarkBg 
+           | LightBg 
+           | NoColor
+
+newtype Args = Args { color :: Color }
+
+colorReader :: ReadM Color
+colorReader = maybeReader colorReader'
+  where
+    colorReader' "dark-bg"  = Just DarkBg
+    colorReader' "light-bg" = Just LightBg
+    colorReader' "no-color" = Just NoColor
+    colorReader' _          = Nothing
+
+args :: Parser Args
+args = Args 
+    <$> option colorReader
+        ( long "color"
+       <> short 'c'
+       <> help "Select printing color. Available options: dark-bg (default), light-bg, no-color."
+       <> showDefaultWith (\_ -> "dark-bg")
+       <> value DarkBg
+        )
 
 main :: IO ()
 main = do
+  args' <- execParser opts 
   input <- T.getContents
-  let output = pString $ unpack input
+  let printOpt = getPrintOpt $ color args'
+      output = pStringOpt printOpt $ unpack input
   LT.putStr output
+  where
+    opts = info (args <**> helper)
+      ( fullDesc
+     <> progDesc "Format Haskell data types with indentation and highlighting"
+      )
+
+    getPrintOpt :: Color -> OutputOptions
+    getPrintOpt DarkBg  = defaultOutputOptionsDarkBg
+    getPrintOpt LightBg = defaultOutputOptionsLightBg
+    getPrintOpt NoColor = defaultOutputOptionsNoColor

--- a/pretty-simple.cabal
+++ b/pretty-simple.cabal
@@ -50,7 +50,6 @@ executable pretty-simple
   hs-source-dirs:      app
   build-depends:       base
                      , pretty-simple
-                     , semigroups
                      , text
                      , optparse-applicative
   default-language:    Haskell2010

--- a/pretty-simple.cabal
+++ b/pretty-simple.cabal
@@ -50,6 +50,7 @@ executable pretty-simple
   hs-source-dirs:      app
   build-depends:       base
                      , pretty-simple
+                     , semigroups
                      , text
                      , optparse-applicative
   default-language:    Haskell2010

--- a/pretty-simple.cabal
+++ b/pretty-simple.cabal
@@ -51,6 +51,7 @@ executable pretty-simple
   build-depends:       base
                      , pretty-simple
                      , text
+                     , optparse-applicative
   default-language:    Haskell2010
   ghc-options:         -Wall -threaded -rtsopts -with-rtsopts=-N
 


### PR DESCRIPTION
#34 . Not super comfortable with this, but I guess it works. Allows optional argument --color or -c with options dark-bg, light-bg, no-color (default dark-bg).