### PR TITLE
Quick fix for issue #40

### DIFF
--- a/src/Text/Pretty/Simple/Internal/ExprParser.hs
+++ b/src/Text/Pretty/Simple/Internal/ExprParser.hs
@@ -58,6 +58,8 @@ parseCSep end s@(c:cs)
 parseStringLit :: String -> (String, String)
 parseStringLit [] = ("", "")
 parseStringLit ('"':rest) = ("", rest)
+parseStringLit ('\\':c:cs) = ('\\':c:cs', rest)
+  where (cs', rest) = parseStringLit cs
 parseStringLit (c:cs)   = (c:cs', rest)
   where (cs', rest) = parseStringLit cs
 


### PR DESCRIPTION
I simply added a case for ignoring the next character after a backslash in `parseStringLit`.

Fixes #40.