### PR TITLE
Highlight numbers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -98,9 +98,9 @@ matrix:
   #  compiler: ": #stack 8.0.1"
   #  addons: {apt: {packages: [libgmp-dev]}}
 
-  - env: BUILD=stack ARGS="--resolver lts-9"
-    compiler: ": #stack 8.0.2"
-    addons: {apt: {packages: [libgmp-dev]}}
+  # - env: BUILD=stack ARGS="--resolver lts-9"
+  #   compiler: ": #stack 8.0.2"
+  #   addons: {apt: {packages: [libgmp-dev]}}
 
   - env: BUILD=stack ARGS="--resolver lts-11"
     compiler: ": #stack 8.2.2"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 
+## 3.1.0.0
+
+*   Numbers are now highlighted in green by default.  Implemented in
+    [#51](https://github.com/cdepillabout/pretty-simple/pull/51).
+    Thanks [lawrencebell](https://github.com/lawrencebell)!
+
 ## 3.0.0.0
 
 *   pretty-simple now escapes non-printable characters by default.  A field

--- a/Setup.hs
+++ b/Setup.hs
@@ -1,2 +1,33 @@
+{-# LANGUAGE CPP #-}
+{-# OPTIONS_GHC -Wall #-}
+module Main (main) where
+
+#ifndef MIN_VERSION_cabal_doctest
+#define MIN_VERSION_cabal_doctest(x,y,z) 0
+#endif
+
+#if MIN_VERSION_cabal_doctest(1,0,0)
+
+import Distribution.Extra.Doctest ( defaultMainWithDoctests )
+main :: IO ()
+main = defaultMainWithDoctests "pretty-simple-doctest"
+
+#else
+
+#ifdef MIN_VERSION_Cabal
+-- If the macro is defined, we have new cabal-install,
+-- but for some reason we don't have cabal-doctest in package-db
+--
+-- Probably we are running cabal sdist, when otherwise using new-build
+-- workflow
+#warning You are configuring this package without cabal-doctest installed. \
+         The doctests test-suite will not work as a result. \
+         To fix this, install cabal-doctest before configuring.
+#endif
+
 import Distribution.Simple
+
+main :: IO ()
 main = defaultMain
+
+#endif

--- a/pretty-simple.cabal
+++ b/pretty-simple.cabal
@@ -1,5 +1,5 @@
 name:                pretty-simple
-version:             3.0.0.0
+version:             3.1.0.0
 synopsis:            pretty printer for data types with a 'Show' instance.
 description:         Please see <https://github.com/cdepillabout/pretty-simple#readme README.md>.
 homepage:            https://github.com/cdepillabout/pretty-simple

--- a/pretty-simple.cabal
+++ b/pretty-simple.cabal
@@ -9,11 +9,16 @@ author:              Dennis Gosnell
 maintainer:          cdep.illabout@gmail.com
 copyright:           2017-2019 Dennis Gosnell
 category:            Text
-build-type:          Simple
+build-type:          Custom
 extra-source-files:  CHANGELOG.md
                    , README.md
                    , img/pretty-simple-example-screenshot.png
 cabal-version:       >=1.10
+
+custom-setup
+  setup-depends:     base
+                   , Cabal
+                   , cabal-doctest >=1.0.2
 
 flag buildexe
   description: Build an small command line program that pretty-print anything from stdin.
@@ -36,6 +41,7 @@ library
                      , Text.Pretty.Simple.Internal.OutputPrinter
   build-depends:       base >= 4.8 && < 5
                      , ansi-terminal >= 0.6
+                     , containers
                      , mtl >= 2.2
                      , text >= 1.2
                      , transformers >= 0.4
@@ -97,6 +103,8 @@ test-suite pretty-simple-doctest
   build-depends:       base
                      , doctest
                      , Glob
+                     , QuickCheck
+                     , template-haskell
   default-language:    Haskell2010
   ghc-options:         -Wall -threaded -rtsopts -with-rtsopts=-N
 

--- a/pretty-simple.cabal
+++ b/pretty-simple.cabal
@@ -101,7 +101,7 @@ test-suite pretty-simple-doctest
   main-is:             DocTest.hs
   hs-source-dirs:      test
   build-depends:       base
-                     , doctest
+                     , doctest >= 0.13
                      , Glob
                      , QuickCheck
                      , template-haskell

--- a/src/Text/Pretty/Simple/Internal/Color.hs
+++ b/src/Text/Pretty/Simple/Internal/Color.hs
@@ -46,7 +46,7 @@ data ColorOptions = ColorOptions
   , colorError :: Builder
   -- ^ (currently not used)
   , colorNum :: Builder
-  -- ^ (currently not used)
+  -- ^ Color to use for numbers.
   , colorRainbowParens :: [Builder]
   -- ^ A list of 'Builder' colors to use for rainbow parenthesis output.  Use
   -- '[]' if you don't want rainbow parenthesis.  Use just a single item if you

--- a/src/Text/Pretty/Simple/Internal/Expr.hs
+++ b/src/Text/Pretty/Simple/Internal/Expr.hs
@@ -36,5 +36,11 @@ data Expr
   | Braces !(CommaSeparated [Expr])
   | Parens !(CommaSeparated [Expr])
   | StringLit !String
+  | IntegerLit !String
+  -- ^ We could store this as an 'Integer', say, instead of a 'String'.
+  -- However, we will never need to use its value for anything. Indeed, the
+  -- only thing we will be doing with it is turning it /back/ into a string
+  -- at some stage, so we might as well cut out the middle man and store it
+  -- directly like this.
   | Other !String
   deriving (Data, Eq, Generic, Show, Typeable)

--- a/src/Text/Pretty/Simple/Internal/Expr.hs
+++ b/src/Text/Pretty/Simple/Internal/Expr.hs
@@ -36,8 +36,8 @@ data Expr
   | Braces !(CommaSeparated [Expr])
   | Parens !(CommaSeparated [Expr])
   | StringLit !String
-  | IntegerLit !String
-  -- ^ We could store this as an 'Integer', say, instead of a 'String'.
+  | NumberLit !String
+  -- ^ We could store this as a 'Rational', say, instead of a 'String'.
   -- However, we will never need to use its value for anything. Indeed, the
   -- only thing we will be doing with it is turning it /back/ into a string
   -- at some stage, so we might as well cut out the middle man and store it

--- a/src/Text/Pretty/Simple/Internal/ExprParser.hs
+++ b/src/Text/Pretty/Simple/Internal/ExprParser.hs
@@ -20,6 +20,7 @@ module Text.Pretty.Simple.Internal.ExprParser
 
 import Text.Pretty.Simple.Internal.Expr (CommaSeparated(..), Expr(..))
 import Control.Arrow (first)
+import Data.Char (isDigit)
 
 testString1, testString2 :: String
 testString1 = "Just [TextInput {textInputClass = Just (Class {unClass = \"class\"}), textInputId = Just (Id {unId = \"id\"}), textInputName = Just (Name {unName = \"name\"}), textInputValue = Just (Value {unValue = \"value\"}), textInputPlaceholder = Just (Placeholder {unPlaceholder = \"placeholder\"})}, TextInput {textInputClass = Just (Class {unClass = \"class\"}), textInputId = Just (Id {unId = \"id\"}), textInputName = Just (Name {unName = \"name\"}), textInputValue = Just (Value {unValue = \"value\"}), textInputPlaceholder = Just (Placeholder {unPlaceholder = \"placeholder\"})}]"
@@ -33,6 +34,7 @@ parseExpr ('(':rest) = first (Parens . CommaSeparated) $ parseCSep ')' rest
 parseExpr ('[':rest) = first (Brackets . CommaSeparated) $ parseCSep ']' rest
 parseExpr ('{':rest) = first (Braces . CommaSeparated) $ parseCSep '}' rest
 parseExpr ('"':rest) = first StringLit $ parseStringLit rest
+parseExpr (c:rest) | isDigit c = first IntegerLit $ parseIntegerLit c rest
 parseExpr other      = first Other $ parseOther other
 
 parseExprs :: String -> ([Expr], String)
@@ -63,8 +65,11 @@ parseStringLit ('\\':c:cs) = ('\\':c:cs', rest)
 parseStringLit (c:cs) = (c:cs', rest)
   where (cs', rest) = parseStringLit cs
 
+parseIntegerLit :: Char -> String -> (String, String)
+parseIntegerLit c = first (c :) . span isDigit
+
 parseOther :: String -> (String, String)
-parseOther = span . flip notElem $ ("{[()]}\"," :: String)
+parseOther = span $ \c -> notElem c ("{[()]}\"," :: String) && not (isDigit c)
 
 -- |
 -- Handle escaped characters correctly

--- a/src/Text/Pretty/Simple/Internal/ExprToOutput.hs
+++ b/src/Text/Pretty/Simple/Internal/ExprToOutput.hs
@@ -38,7 +38,9 @@ import GHC.Generics (Generic)
 import Text.Pretty.Simple.Internal.Expr (CommaSeparated(..), Expr(..))
 import Text.Pretty.Simple.Internal.Output
        (NestLevel(..), Output(..), OutputType(..), unNestLevel)
+
 -- $setup
+-- >>> :set -XOverloadedStrings
 -- >>> import Control.Monad.State (State)
 -- >>> :{
 -- let test :: PrinterState -> State PrinterState [Output] -> [Output]

--- a/src/Text/Pretty/Simple/Internal/ExprToOutput.hs
+++ b/src/Text/Pretty/Simple/Internal/ExprToOutput.hs
@@ -225,6 +225,10 @@ putExpression (StringLit string) = do
   nest <- gets nestLevel
   when (nest < 0) $ addToNestLevel 1
   addOutputs [OutputStringLit string, OutputOther " "]
+putExpression (IntegerLit integer) = do
+  nest <- gets nestLevel
+  when (nest < 0) $ addToNestLevel 1
+  (:[]) <$> (addOutput $ OutputIntegerLit integer)
 putExpression (Other string) = do
   nest <- gets nestLevel
   when (nest < 0) $ addToNestLevel 1

--- a/src/Text/Pretty/Simple/Internal/ExprToOutput.hs
+++ b/src/Text/Pretty/Simple/Internal/ExprToOutput.hs
@@ -225,10 +225,10 @@ putExpression (StringLit string) = do
   nest <- gets nestLevel
   when (nest < 0) $ addToNestLevel 1
   addOutputs [OutputStringLit string, OutputOther " "]
-putExpression (IntegerLit integer) = do
+putExpression (NumberLit integer) = do
   nest <- gets nestLevel
   when (nest < 0) $ addToNestLevel 1
-  (:[]) <$> (addOutput $ OutputIntegerLit integer)
+  (:[]) <$> (addOutput $ OutputNumberLit integer)
 putExpression (Other string) = do
   nest <- gets nestLevel
   when (nest < 0) $ addToNestLevel 1

--- a/src/Text/Pretty/Simple/Internal/Output.hs
+++ b/src/Text/Pretty/Simple/Internal/Output.hs
@@ -70,12 +70,12 @@ data OutputType
   -- of the other tokens.
   | OutputStringLit !String
   -- ^ This represents a string literal.  For instance, @\"foobar\"@.
-  | OutputIntegerLit !String
-  -- ^ This represents an integer literal.  For example, @12345@.
+  | OutputNumberLit !String
+  -- ^ This represents a numeric literal.  For example, @12345@ or @3.14159@.
   deriving (Data, Eq, Generic, Read, Show, Typeable)
 
 -- | 'IsString' (and 'fromString') should generally only be used in tests and
--- debugging.  There is no way to represent 'OutputIndent', 'OutputIntegerLit'
+-- debugging.  There is no way to represent 'OutputIndent', 'OutputNumberLit'
 -- and 'OutputStringLit'.
 instance IsString OutputType where
     fromString :: String -> OutputType

--- a/src/Text/Pretty/Simple/Internal/Output.hs
+++ b/src/Text/Pretty/Simple/Internal/Output.hs
@@ -70,11 +70,13 @@ data OutputType
   -- of the other tokens.
   | OutputStringLit !String
   -- ^ This represents a string literal.  For instance, @\"foobar\"@.
+  | OutputIntegerLit !String
+  -- ^ This represents an integer literal.  For example, @12345@.
   deriving (Data, Eq, Generic, Read, Show, Typeable)
 
 -- | 'IsString' (and 'fromString') should generally only be used in tests and
--- debugging.  There is no way to represent 'OutputIndent' and
--- 'OutputStringLit'.
+-- debugging.  There is no way to represent 'OutputIndent', 'OutputIntegerLit'
+-- and 'OutputStringLit'.
 instance IsString OutputType where
     fromString :: String -> OutputType
     fromString "}" = OutputCloseBrace

--- a/src/Text/Pretty/Simple/Internal/OutputPrinter.hs
+++ b/src/Text/Pretty/Simple/Internal/OutputPrinter.hs
@@ -148,6 +148,12 @@ renderOutput (Output _ (OutputOther string)) = do
   let spaces = replicate (indentSpaces + 2) ' '
   -- TODO: This probably shouldn't be a string to begin with.
   pure $ fromString $ indentSubsequentLinesWith spaces string
+renderOutput (Output _ (OutputIntegerLit integer)) = do
+  sequenceFold
+    [ useColorNum
+    , pure (fromString integer)
+    , useColorReset
+    ]
 renderOutput (Output _ (OutputStringLit string)) = do
   options <- ask
 

--- a/src/Text/Pretty/Simple/Internal/OutputPrinter.hs
+++ b/src/Text/Pretty/Simple/Internal/OutputPrinter.hs
@@ -148,10 +148,10 @@ renderOutput (Output _ (OutputOther string)) = do
   let spaces = replicate (indentSpaces + 2) ' '
   -- TODO: This probably shouldn't be a string to begin with.
   pure $ fromString $ indentSubsequentLinesWith spaces string
-renderOutput (Output _ (OutputIntegerLit integer)) = do
+renderOutput (Output _ (OutputNumberLit number)) = do
   sequenceFold
     [ useColorNum
-    , pure (fromString integer)
+    , pure (fromString number)
     , useColorReset
     ]
 renderOutput (Output _ (OutputStringLit string)) = do

--- a/test/DocTest.hs
+++ b/test/DocTest.hs
@@ -1,40 +1,12 @@
+module Main where
 
-module Main (main) where
-
-import Prelude
-
-import Data.Monoid ((<>))
-import System.FilePath.Glob (glob)
+import Build_doctests (flags, pkgs, module_sources)
+-- import Data.Foldable (traverse_)
 import Test.DocTest (doctest)
 
 main :: IO ()
-main = glob "src/**/*.hs" >>= doDocTest
-
-doDocTest :: [String] -> IO ()
-doDocTest options = doctest $ options <> ghcExtensions
-
-ghcExtensions :: [String]
-ghcExtensions =
-    [
-    --   "-XConstraintKinds"
-    -- , "-XDataKinds"
-      "-XDeriveDataTypeable"
-    , "-XDeriveGeneric"
-    -- , "-XEmptyDataDecls"
-    , "-XFlexibleContexts"
-    -- , "-XFlexibleInstances"
-    -- , "-XGADTs"
-    -- , "-XGeneralizedNewtypeDeriving"
-    -- , "-XInstanceSigs"
-    -- , "-XMultiParamTypeClasses"
-    -- , "-XNoImplicitPrelude"
-    , "-XOverloadedStrings"
-    -- , "-XPolyKinds"
-    -- , "-XRankNTypes"
-    -- , "-XRecordWildCards"
-    , "-XScopedTypeVariables"
-    -- , "-XStandaloneDeriving"
-    -- , "-XTupleSections"
-    -- , "-XTypeFamilies"
-    -- , "-XTypeOperators"
-    ]
+main = do
+  -- traverse_ putStrLn args
+  doctest args
+  where
+    args = flags ++ pkgs ++ module_sources


### PR DESCRIPTION
This adds highlighting to numbers, closes #4.  Also closes #49.

It's a pretty straightforward diff on the whole. We add a `NumberLit` constructor to `Expr`, and a `OutputNumberLit` to `OutputType`. These are hooked up in the obvious way.

Then we have a function `parseNumberLit` for parsing numbers. I've just handled integers (strings matching the regex `[0-9]+`) and decimals (strings matching the regex `[0-9]+\.[0-9]+`) for now. There is a question here about what exactly we want to treat as a number. You could imagine that maybe we would want to extend this in future to cover some or all of

- hex/octal/binary syntax,
- exponents in decimal notation (like `1e2` for example),
- numeric underscores,
- omitted leading digits (like `.123`),
- leading plus/minus signs?

A more tricky change is the modification of `parseOther` to accommodate this - as the syntax we care about has grown, `parseOther` needs to stop consuming input in more cases.

I chose to make it so that numbers as part of identifiers aren't highlighted as numbers. For example, given

```haskell
data Foo = Foo { foo1 :: Integer , foo2 :: [String] } deriving Show
data Bar = Bar { bar1 :: Double , bar2 :: [Foo] } deriving Show

foo = Foo 3 ["hello", "goodbye"]
```

consider the result of `pPrint foo`

```
Foo 
    { foo1 = 3
    , foo2 = 
        [ "hello" 
        , "goodbye" 
        ] 
    } 
```

Do we want the '1' in `foo1` and the '2' in `foo2` to be highlighted as numbers? My feeling was that, as we are mainly (entirely?) showing Haskell data structures, it makes sense to leave `foo1` and `foo2` un-highlighted, whilst highlighting the bare `3` here. More generally, I implemented the rule that we don't highlight numbers that form part of Haskell-style identifiers.