### PR TITLE
Fix build with GHC-7.10.3

### DIFF
--- a/pretty-simple.cabal
+++ b/pretty-simple.cabal
@@ -17,7 +17,7 @@ cabal-version:       >=1.10
 
 custom-setup
   setup-depends:     base
-                   , Cabal
+                   , Cabal >= 1.24
                    , cabal-doctest >=1.0.2
 
 flag buildexe


### PR DESCRIPTION
Previously I would see the following build failure:

    $ cabal-3.0 build -w ghc-7.10.3
    Resolving dependencies...
    Build profile: -w ghc-7.10.3 -O1
    In order, the following will be built (use -v for more details):
     - pretty-simple-3.1.0.0 (lib:pretty-simple) (first run)
    Warning: pretty-simple.cabal: Ignoring unknown section type: custom-setup
    Configuring pretty-simple-3.1.0.0...
    setup: At least the following dependencies are missing:
    aeson -any, bytestring -any, optparse-applicative -any

https://github.com/haskell/cabal/issues/3881 seems related but
I don't fully understand the issue.