### PR TITLE
Fix parsing for identifiers containing "'"

### DIFF
--- a/src/Text/Pretty/Simple/Internal/ExprParser.hs
+++ b/src/Text/Pretty/Simple/Internal/ExprParser.hs
@@ -155,6 +155,10 @@ parseNumberLit firstDigit rest1 =
 -- ("H3110 World","")
 -- >>> parseOther "Node' (Leaf' 1) (Leaf' 2)"
 -- ("Node' ","(Leaf' 1) (Leaf' 2)")
+-- >>> parseOther "I'm One"
+-- ("I'm One","")
+-- >>> parseOther "I'm 2"
+-- ("I'm ","2")
 parseOther :: String -> (String, String)
 parseOther = go False
   where


### PR DESCRIPTION
Closes #63.

This works by simply using the same logic for `'` that we use for digits w.r.t. appearing in identifiers. Obviously they're not entirely equivalent in general because `'` can only appear at the end of an identifier, but I don't believe there's any situation here where that difference is important.