### PR TITLE
Changes to enable usage of prettyprinter backends

### DIFF
--- a/src/Text/Pretty/Simple.hs
+++ b/src/Text/Pretty/Simple.hs
@@ -101,9 +101,15 @@ module Text.Pretty.Simple
   , defaultOutputOptionsNoColor
   , CheckColorTty(..)
   -- * 'ColorOptions'
-  -- $colorOptions
   , defaultColorOptionsDarkBg
   , defaultColorOptionsLightBg
+  , ColorOptions(..)
+  , Style(..)
+  , Color(..)
+  , Intensity(..)
+  , color
+  , colorBold
+  , colorNull
   -- * Examples
   -- $examples
   ) where
@@ -116,11 +122,16 @@ import Control.Applicative
 
 import Control.Monad.IO.Class (MonadIO, liftIO)
 import Data.Text.Lazy (Text)
-import Prettyprinter.Render.Terminal (renderLazy, renderIO)
+import Prettyprinter (SimpleDocStream)
+import Prettyprinter.Render.Terminal
+      (Color (..), Intensity(Vivid,Dull), AnsiStyle,
+       renderLazy, renderIO)
 import System.IO (Handle, stdout)
 
 import Text.Pretty.Simple.Internal
-       (CheckColorTty(..), OutputOptions(..), StringOutputStyle(..),
+       (ColorOptions(..), Style(..), CheckColorTty(..),
+        OutputOptions(..), StringOutputStyle(..),
+        convertStyle, colorNull, color, colorBold,
         defaultColorOptionsDarkBg, defaultColorOptionsLightBg,
         defaultOutputOptionsDarkBg, defaultOutputOptionsLightBg,
         defaultOutputOptionsNoColor, hCheckTTY, layoutString)
@@ -520,7 +531,7 @@ pHPrintStringOpt checkColorTty outputOptions handle str = do
       CheckColorTty -> hCheckTTY handle outputOptions
       NoCheckColorTty -> pure outputOptions
   liftIO $ do
-    renderIO handle $ layoutString realOutputOpts str
+    renderIO handle $ layoutStringAnsi realOutputOpts str
     putStrLn ""
 
 -- | Like 'pShow' but takes 'OutputOptions' to change how the
@@ -531,12 +542,10 @@ pShowOpt outputOptions = pStringOpt outputOptions . show
 -- | Like 'pString' but takes 'OutputOptions' to change how the
 -- pretty-printing is done.
 pStringOpt :: OutputOptions -> String -> Text
-pStringOpt outputOptions = renderLazy . layoutString outputOptions
+pStringOpt outputOptions = renderLazy . layoutStringAnsi outputOptions
 
--- $colorOptions
---
--- Additional settings for color options can be found in
--- "Text.Pretty.Simple.Internal.Color".
+layoutStringAnsi :: OutputOptions -> String -> SimpleDocStream AnsiStyle
+layoutStringAnsi opts = fmap convertStyle . layoutString opts
 
 -- $examples
 --

--- a/src/Text/Pretty/Simple.hs
+++ b/src/Text/Pretty/Simple.hs
@@ -107,8 +107,6 @@ module Text.Pretty.Simple
   , Style(..)
   , Color(..)
   , Intensity(..)
-  , color
-  , colorBold
   , colorNull
   -- * Examples
   -- $examples
@@ -131,7 +129,7 @@ import System.IO (Handle, stdout)
 import Text.Pretty.Simple.Internal
        (ColorOptions(..), Style(..), CheckColorTty(..),
         OutputOptions(..), StringOutputStyle(..),
-        convertStyle, colorNull, color, colorBold,
+        convertStyle, colorNull,
         defaultColorOptionsDarkBg, defaultColorOptionsLightBg,
         defaultOutputOptionsDarkBg, defaultOutputOptionsLightBg,
         defaultOutputOptionsNoColor, hCheckTTY, layoutString)

--- a/src/Text/Pretty/Simple/Internal/Color.hs
+++ b/src/Text/Pretty/Simple/Internal/Color.hs
@@ -35,9 +35,6 @@ import qualified Prettyprinter.Render.Terminal as Ansi
 
 -- | These options are for colorizing the output of functions like 'pPrint'.
 --
--- For example, if you set 'colorQuote' to something like 'colorBold Vivid Blue',
--- then the quote character (@\"@) will be output as bright blue in bold.
---
 -- If you don't want to use a color for one of the options, use 'colorNull'.
 data ColorOptions = ColorOptions
   { colorQuote :: Style
@@ -107,6 +104,7 @@ colorNull = Style
   , styleUnderlined = False
   }
 
+-- | Ways to style terminal output.
 data Style = Style
   { styleColor :: Maybe (Color, Intensity)
   , styleBold :: Bool

--- a/src/Text/Pretty/Simple/Internal/Color.hs
+++ b/src/Text/Pretty/Simple/Internal/Color.hs
@@ -103,33 +103,32 @@ colorNull :: Style
 colorNull = Style
   { styleColor = Nothing
   , styleBold = False
-  , styleIntensity = Dull
+  , styleItalic = False
+  , styleUnderlined = False
   }
 
 data Style = Style
-  { styleColor :: Maybe Color
+  { styleColor :: Maybe (Color, Intensity)
   , styleBold :: Bool
-  , styleIntensity :: Intensity
+  , styleItalic :: Bool
+  , styleUnderlined :: Bool
   }
   deriving (Eq, Show)
 
-color' :: Bool -> Intensity -> Color -> Style
-color' b i c = Style
-  { styleColor = Just c
-  , styleBold = b
-  , styleIntensity = i
-  }
-
 color :: Intensity -> Color -> Style
-color = color' False
+color i c = colorNull {styleColor = Just (c, i)}
 
 colorBold :: Intensity -> Color -> Style
-colorBold = color' True
+colorBold i c = (color i c) {styleBold = True}
 
 convertStyle :: Style -> AnsiStyle
 convertStyle Style {..} =
-  (if styleBold then Ansi.bold else mempty)
-    <> maybe mempty (col styleIntensity) styleColor
+  mconcat
+    [ maybe mempty (uncurry $ flip col) styleColor
+    , if styleBold then Ansi.bold else mempty
+    , if styleItalic then Ansi.italicized else mempty
+    , if styleUnderlined then Ansi.underlined else mempty
+    ]
   where
     col = \case
       Vivid -> Ansi.color

--- a/src/Text/Pretty/Simple/Internal/Color.hs
+++ b/src/Text/Pretty/Simple/Internal/Color.hs
@@ -2,8 +2,10 @@
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TemplateHaskell #-}
 
@@ -25,262 +27,110 @@ module Text.Pretty.Simple.Internal.Color
 import Control.Applicative
 #endif
 
-import Prettyprinter.Render.Terminal
-  (AnsiStyle, Color(..), bold, colorDull, color)
 import Data.Typeable (Typeable)
 import GHC.Generics (Generic)
+import Prettyprinter.Render.Terminal
+  (AnsiStyle, Intensity(Dull,Vivid), Color(..))
+import qualified Prettyprinter.Render.Terminal as Ansi
 
 -- | These options are for colorizing the output of functions like 'pPrint'.
 --
--- For example, if you set 'colorQuote' to something like 'colorVividBlueBold',
+-- For example, if you set 'colorQuote' to something like 'colorBold Vivid Blue',
 -- then the quote character (@\"@) will be output as bright blue in bold.
 --
 -- If you don't want to use a color for one of the options, use 'colorNull'.
 data ColorOptions = ColorOptions
-  { colorQuote :: AnsiStyle
+  { colorQuote :: Style
   -- ^ Color to use for quote characters (@\"@) around strings.
-  , colorString :: AnsiStyle
+  , colorString :: Style
   -- ^ Color to use for strings.
-  , colorError :: AnsiStyle
+  , colorError :: Style
   -- ^ Color for errors, e.g. unmatched brackets.
-  , colorNum :: AnsiStyle
+  , colorNum :: Style
   -- ^ Color to use for numbers.
-  , colorRainbowParens :: [AnsiStyle]
-  -- ^ A list of 'Builder' colors to use for rainbow parenthesis output.  Use
+  , colorRainbowParens :: [Style]
+  -- ^ A list of colors to use for rainbow parenthesis output.  Use
   -- '[]' if you don't want rainbow parenthesis.  Use just a single item if you
   -- want all the rainbow parenthesis to be colored the same.
   } deriving (Eq, Generic, Show, Typeable)
 
-------------------------------------
--- Dark background default colors --
-------------------------------------
-
 -- | Default color options for use on a dark background.
---
--- 'colorQuote' is 'defaultColorQuoteDarkBg'. 'colorString' is
--- 'defaultColorStringDarkBg'.  'colorError' is 'defaultColorErrorDarkBg'.
--- 'colorNum' is 'defaultColorNumDarkBg'.  'colorRainbowParens' is
--- 'defaultColorRainboxParensDarkBg'.
 defaultColorOptionsDarkBg :: ColorOptions
 defaultColorOptionsDarkBg =
   ColorOptions
-  { colorQuote = defaultColorQuoteDarkBg
-  , colorString = defaultColorStringDarkBg
-  , colorError = defaultColorErrorDarkBg
-  , colorNum = defaultColorNumDarkBg
-  , colorRainbowParens = defaultColorRainbowParensDarkBg
+  { colorQuote = colorBold Vivid White
+  , colorString = colorBold Vivid Blue
+  , colorError = colorBold Vivid Red
+  , colorNum = colorBold Vivid Green
+  , colorRainbowParens =
+    [ colorBold Vivid Magenta
+    , colorBold Vivid Cyan
+    , colorBold Vivid Yellow
+    , color Dull Magenta
+    , color Dull Cyan
+    , color Dull Yellow
+    , colorBold Dull Magenta
+    , colorBold Dull Cyan
+    , colorBold Dull Yellow
+    , color Vivid Magenta
+    , color Vivid Cyan
+    , color Vivid Yellow
+    ]
   }
 
--- | Default color for 'colorQuote' for dark backgrounds. This is
--- 'colorVividWhiteBold'.
-defaultColorQuoteDarkBg :: AnsiStyle
-defaultColorQuoteDarkBg = colorVividWhiteBold
-
--- | Default color for 'colorString' for dark backgrounds. This is
--- 'colorVividBlueBold'.
-defaultColorStringDarkBg :: AnsiStyle
-defaultColorStringDarkBg = colorVividBlueBold
-
--- | Default color for 'colorError' for dark backgrounds.  This is
--- 'colorVividRedBold'.
-defaultColorErrorDarkBg :: AnsiStyle
-defaultColorErrorDarkBg = colorVividRedBold
-
--- | Default color for 'colorNum' for dark backgrounds.  This is
--- 'colorVividGreenBold'.
-defaultColorNumDarkBg :: AnsiStyle
-defaultColorNumDarkBg = colorVividGreenBold
-
--- | Default colors for 'colorRainbowParens' for dark backgrounds.
-defaultColorRainbowParensDarkBg :: [AnsiStyle]
-defaultColorRainbowParensDarkBg =
-  [ colorVividMagentaBold
-  , colorVividCyanBold
-  , colorVividYellowBold
-  , colorDullMagenta
-  , colorDullCyan
-  , colorDullYellow
-  , colorDullMagentaBold
-  , colorDullCyanBold
-  , colorDullYellowBold
-  , colorVividMagenta
-  , colorVividCyan
-  , colorVividYellow
-  ]
-
--------------------------------------
--- Light background default colors --
--------------------------------------
-
 -- | Default color options for use on a light background.
---
--- 'colorQuote' is 'defaultColorQuoteLightBg'. 'colorString' is
--- 'defaultColorStringLightBg'.  'colorError' is 'defaultColorErrorLightBg'.
--- 'colorNum' is 'defaultColorNumLightBg'.  'colorRainbowParens' is
--- 'defaultColorRainboxParensLightBg'.
 defaultColorOptionsLightBg :: ColorOptions
 defaultColorOptionsLightBg =
   ColorOptions
-  { colorQuote = defaultColorQuoteLightBg
-  , colorString = defaultColorStringLightBg
-  , colorError = defaultColorErrorLightBg
-  , colorNum = defaultColorNumLightBg
-  , colorRainbowParens = defaultColorRainbowParensLightBg
+  { colorQuote = colorBold Vivid Black
+  , colorString = colorBold Vivid Blue
+  , colorError = colorBold Vivid Red
+  , colorNum = colorBold Vivid Green
+  , colorRainbowParens =
+    [ colorBold Vivid Magenta
+    , colorBold Vivid Cyan
+    , color Dull Magenta
+    , color Dull Cyan
+    , colorBold Dull Magenta
+    , colorBold Dull Cyan
+    , color Vivid Magenta
+    , color Vivid Cyan
+    ]
   }
 
--- | Default color for 'colorQuote' for light backgrounds. This is
--- 'colorVividWhiteBold'.
-defaultColorQuoteLightBg :: AnsiStyle
-defaultColorQuoteLightBg = colorVividBlackBold
+-- | No styling.
+colorNull :: Style
+colorNull = Style
+  { styleColor = Nothing
+  , styleBold = False
+  , styleIntensity = Dull
+  }
 
--- | Default color for 'colorString' for light backgrounds. This is
--- 'colorVividBlueBold'.
-defaultColorStringLightBg :: AnsiStyle
-defaultColorStringLightBg = colorVividBlueBold
+data Style = Style
+  { styleColor :: Maybe Color
+  , styleBold :: Bool
+  , styleIntensity :: Intensity
+  }
+  deriving (Eq, Show)
 
--- | Default color for 'colorError' for light backgrounds.  This is
--- 'colorVividRedBold'.
-defaultColorErrorLightBg :: AnsiStyle
-defaultColorErrorLightBg = colorVividRedBold
+color' :: Bool -> Intensity -> Color -> Style
+color' b i c = Style
+  { styleColor = Just c
+  , styleBold = b
+  , styleIntensity = i
+  }
 
--- | Default color for 'colorNum' for light backgrounds.  This is
--- 'colorVividGreenBold'.
-defaultColorNumLightBg :: AnsiStyle
-defaultColorNumLightBg = colorVividGreenBold
+color :: Intensity -> Color -> Style
+color = color' False
 
--- | Default colors for 'colorRainbowParens' for light backgrounds.
-defaultColorRainbowParensLightBg :: [AnsiStyle]
-defaultColorRainbowParensLightBg =
-  [ colorVividMagentaBold
-  , colorVividCyanBold
-  , colorDullMagenta
-  , colorDullCyan
-  , colorDullMagentaBold
-  , colorDullCyanBold
-  , colorVividMagenta
-  , colorVividCyan
-  ]
+colorBold :: Intensity -> Color -> Style
+colorBold = color' True
 
------------------------
--- Vivid Bold Colors --
------------------------
-
-colorVividBlackBold :: AnsiStyle
-colorVividBlackBold = colorBold `mappend` colorVividBlack
-
-colorVividBlueBold :: AnsiStyle
-colorVividBlueBold = colorBold `mappend` colorVividBlue
-
-colorVividCyanBold :: AnsiStyle
-colorVividCyanBold = colorBold `mappend` colorVividCyan
-
-colorVividGreenBold :: AnsiStyle
-colorVividGreenBold = colorBold `mappend` colorVividGreen
-
-colorVividMagentaBold :: AnsiStyle
-colorVividMagentaBold = colorBold `mappend` colorVividMagenta
-
-colorVividRedBold :: AnsiStyle
-colorVividRedBold = colorBold `mappend` colorVividRed
-
-colorVividWhiteBold :: AnsiStyle
-colorVividWhiteBold = colorBold `mappend` colorVividWhite
-
-colorVividYellowBold :: AnsiStyle
-colorVividYellowBold = colorBold `mappend` colorVividYellow
-
------------------------
--- Dull Bold Colors --
------------------------
-
-colorDullBlackBold :: AnsiStyle
-colorDullBlackBold = colorBold `mappend` colorDullBlack
-
-colorDullBlueBold :: AnsiStyle
-colorDullBlueBold = colorBold `mappend` colorDullBlue
-
-colorDullCyanBold :: AnsiStyle
-colorDullCyanBold = colorBold `mappend` colorDullCyan
-
-colorDullGreenBold :: AnsiStyle
-colorDullGreenBold = colorBold `mappend` colorDullGreen
-
-colorDullMagentaBold :: AnsiStyle
-colorDullMagentaBold = colorBold `mappend` colorDullMagenta
-
-colorDullRedBold :: AnsiStyle
-colorDullRedBold = colorBold `mappend` colorDullRed
-
-colorDullWhiteBold :: AnsiStyle
-colorDullWhiteBold = colorBold `mappend` colorDullWhite
-
-colorDullYellowBold :: AnsiStyle
-colorDullYellowBold = colorBold `mappend` colorDullYellow
-
-------------------
--- Vivid Colors --
-------------------
-
-colorVividBlack :: AnsiStyle
-colorVividBlack = color Black
-
-colorVividBlue :: AnsiStyle
-colorVividBlue = color Blue
-
-colorVividCyan :: AnsiStyle
-colorVividCyan = color Cyan
-
-colorVividGreen :: AnsiStyle
-colorVividGreen = color Green
-
-colorVividMagenta :: AnsiStyle
-colorVividMagenta = color Magenta
-
-colorVividRed :: AnsiStyle
-colorVividRed = color Red
-
-colorVividWhite :: AnsiStyle
-colorVividWhite = color White
-
-colorVividYellow :: AnsiStyle
-colorVividYellow = color Yellow
-
-------------------
--- Dull Colors --
-------------------
-
-colorDullBlack :: AnsiStyle
-colorDullBlack = colorDull Black
-
-colorDullBlue :: AnsiStyle
-colorDullBlue = colorDull Blue
-
-colorDullCyan :: AnsiStyle
-colorDullCyan = colorDull Cyan
-
-colorDullGreen :: AnsiStyle
-colorDullGreen = colorDull Green
-
-colorDullMagenta :: AnsiStyle
-colorDullMagenta = colorDull Magenta
-
-colorDullRed :: AnsiStyle
-colorDullRed = colorDull Red
-
-colorDullWhite :: AnsiStyle
-colorDullWhite = colorDull White
-
-colorDullYellow :: AnsiStyle
-colorDullYellow = colorDull Yellow
-
---------------------
--- Special Colors --
---------------------
-
--- | Change the intensity to 'BoldIntensity'.
-colorBold :: AnsiStyle
-colorBold = bold
-
--- | Empty string.
-colorNull :: AnsiStyle
-colorNull = mempty
+convertStyle :: Style -> AnsiStyle
+convertStyle Style {..} =
+  (if styleBold then Ansi.bold else mempty)
+    <> maybe mempty (col styleIntensity) styleColor
+  where
+    col = \case
+      Vivid -> Ansi.color
+      Dull -> Ansi.colorDull


### PR DESCRIPTION
Using `prettyprinter-ansi-terminal`'s `AnsiStyle` to represent colours was not ideal as it is intentionally opaque, and so it's difficult to convert to another format.

This PR introduces a new `Style` type corresponding to the subset of `AnsiStyle` which is used in `pretty-simple`.

There is some inconsistency in whether we refer to things as "style"s or "colour"s. This `Style` type allows customising whether the text is bold, so it does represent more than just colour. But changing all instances of "color" to "style" would seem an unnecessary break of backwards compatibility. This isn't really a new issue, but this change has made it more obvious.