### PR TITLE
Add `cabal repl` instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ $ stack ghci --package pretty-simple
 Or, with cabal:
 
 ```sh
-$ cabal repl -b pretty-simple
+$ cabal repl --build-depends pretty-simple
 ```
 
 Once you get a prompt in `ghci`, you can use `import` to get `pretty-simple`'s
@@ -118,7 +118,7 @@ All you need to do is run GHCi with a command like one of these:
 $ stack ghci --ghci-options "-interactive-print=Text.Pretty.Simple.pPrint" --package pretty-simple
 ```
 ```sh
-$ cabal repl --repl-options "-interactive-print=Text.Pretty.Simple.pPrint" -b pretty-simple
+$ cabal repl --repl-options "-interactive-print=Text.Pretty.Simple.pPrint" --build-depends pretty-simple
 ```
 
 Now, whenever you make GHCi evaluate an expression, GHCi will pretty-print the

--- a/README.md
+++ b/README.md
@@ -44,10 +44,16 @@ more deeply nested.  It would be even more difficult to read.
 `pretty-simple` can be easily used from `ghci` when debugging.
 
 When using `stack` to run `ghci`, just append the `--package` flag to
-the command line to load `pretty-simple`.
+the command line to load `pretty-simple`:
 
 ```sh
 $ stack ghci --package pretty-simple
+```
+
+Or, with cabal:
+
+```sh
+$ cabal repl -b pretty-simple
 ```
 
 Once you get a prompt in `ghci`, you can use `import` to get `pretty-simple`'s
@@ -106,10 +112,13 @@ Other pretty-printing packages have some combination of these defects:
 
 The `pPrint` function can be used as the default output function in GHCi.
 
-All you need to do is run GHCi like this:
+All you need to do is run GHCi with a command like one of these:
 
 ```sh
 $ stack ghci --ghci-options "-interactive-print=Text.Pretty.Simple.pPrint" --package pretty-simple
+```
+```sh
+$ cabal repl --repl-options "-interactive-print=Text.Pretty.Simple.pPrint" -b pretty-simple
 ```
 
 Now, whenever you make GHCi evaluate an expression, GHCi will pretty-print the


### PR DESCRIPTION
Closes #92.
 
I'm fairly sure `-b` is a safer option than `--package`. In fact, I'm not quite sure what `--package` even does - I think it's a legacy `v1-` thing. `-b` will consult the solver, build a version of `pretty-simple` compatible with the current environment, add it to the global cache, and bring it in to scope in GHCI.