### PR TITLE
Use absolute URLs for images in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ more deeply nested.  It would be even more difficult to read.
 
 `pretty-simple` can be used to print `bar` in an easy-to-read format:
 
-![example screenshot](/img/pretty-simple-example-screenshot.png?raw=true "example screenshot")
+![example screenshot](https://raw.githubusercontent.com/cdepillabout/pretty-simple/master/img/pretty-simple-example-screenshot.png)
 
 ## Usage
 
@@ -175,7 +175,7 @@ Just like Haskell's normal `print` output, this is pretty hard to read.
 `pretty-simple` can be used to pretty-print the JSON-encoded `bar` in an
 easy-to-read format:
 
-![json example screenshot](/img/pretty-simple-json-example-screenshot.png?raw=true "json example screenshot")
+![json example screenshot](https://raw.githubusercontent.com/cdepillabout/pretty-simple/master/img/pretty-simple-json-example-screenshot.png)
 
 (You can find the `lazyByteStringToString`, `putLazyByteStringLn`,
 and `putLazyTextLn` in the [`ExampleJSON.hs`](example/ExampleJSON.hs)
@@ -195,7 +195,7 @@ $ stack install pretty-simple
 When run on the command line, you can paste in the Haskell datatype you want to
 be formatted, then hit <kbd>Ctrl</kbd>-<kbd>D</kbd>:
 
-![cli example screenshot](/img/pretty-simple-cli-screenshot.png?raw=true "cli example screenshot")
+![cli example screenshot](https://raw.githubusercontent.com/cdepillabout/pretty-simple/master/img/pretty-simple-cli-screenshot.png)
 
 This is very useful if you accidentally print out a Haskell data type with
 `print` instead of `pPrint`.


### PR DESCRIPTION
The images in README are not displayed on [Hackage](https://hackage.haskell.org/package/pretty-simple) because the paths are relative. So I've changed URLs to absolute ones. I think some people still encounter `pretty-simple` on Hackage as their first occurrence so it would be good to have images displayed there as well 🎨 

I also pessimistically removed the _title_ part of the markdown rendering not being sure whether the current Hackage markdown supports this. To test this, one needs to create candidate releases and check the output 🤔 

P.S. Feel free to close this PR if this is not what you want 🙂 