### PR TITLE
further reduce newlines for compact output

### DIFF
--- a/src/Text/Pretty/Simple.hs
+++ b/src/Text/Pretty/Simple.hs
@@ -680,6 +680,15 @@ layoutStringAnsi opts = fmap convertStyle . layoutString opts
 --         , B
 --             ( B ( B A ) ) ] )
 --
+-- >>> pPrintOpt CheckColorTty defaultOutputOptionsDarkBg {outputOptionsCompact = True} $ [("id", 123), ("state", 1), ("pass", 1), ("tested", 100), ("time", 12345)]
+-- [
+--     ( "id", 123 ),
+--     ( "state", 1 ),
+--     ( "pass", 1 ),
+--     ( "tested", 100 ),
+--     ( "time", 12345 )
+-- ]
+--
 -- __Initial indent__
 --
 -- >>> pPrintOpt CheckColorTty defaultOutputOptionsDarkBg {outputOptionsInitialIndent = 3} $ B ( B ( B ( B A ) ) )

--- a/src/Text/Pretty/Simple/Internal/Printer.hs
+++ b/src/Text/Pretty/Simple/Internal/Printer.hs
@@ -255,10 +255,7 @@ prettyExpr opts = (if outputOptionsCompact opts then group else id) . \case
             spaceIfNeeded = \case
               Other (' ' : _) : _ -> mempty
               _ -> space
-    lineAndCommaSep x y =
-      if outputOptionsCompact opts
-      then x <> annotate Comma "," <> y
-      else x <> line' <> annotate Comma "," <> y
+    lineAndCommaSep x y = x <> (if outputOptionsCompact opts then mempty else line') <> annotate Comma "," <> y
 
 -- | Determine whether this expression should be displayed on a single line.
 isSimple :: Expr -> Bool

--- a/src/Text/Pretty/Simple/Internal/Printer.hs
+++ b/src/Text/Pretty/Simple/Internal/Printer.hs
@@ -255,7 +255,10 @@ prettyExpr opts = (if outputOptionsCompact opts then group else id) . \case
             spaceIfNeeded = \case
               Other (' ' : _) : _ -> mempty
               _ -> space
-    lineAndCommaSep x y = x <> line' <> annotate Comma "," <> y
+    lineAndCommaSep x y =
+      if outputOptionsCompact opts
+      then x <> annotate Comma "," <> y
+      else x <> line' <> annotate Comma "," <> y
 
 -- | Determine whether this expression should be displayed on a single line.
 isSimple :: Expr -> Bool

--- a/src/Text/Pretty/Simple/Internal/Printer.hs
+++ b/src/Text/Pretty/Simple/Internal/Printer.hs
@@ -255,7 +255,8 @@ prettyExpr opts = (if outputOptionsCompact opts then group else id) . \case
             spaceIfNeeded = \case
               Other (' ' : _) : _ -> mempty
               _ -> space
-    lineAndCommaSep x y = x <> (if outputOptionsCompact opts then mempty else line') <> annotate Comma "," <> y
+    lineAndCommaSep x y = x <> munless (outputOptionsCompact opts) line' <> annotate Comma "," <> y
+    munless b x = if b then mempty else x
 
 -- | Determine whether this expression should be displayed on a single line.
 isSimple :: Expr -> Bool

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,7 @@
 # For more information, see: http://docs.haskellstack.org/en/stable/yaml_configuration.html
 
 # Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
-resolver: lts-18.02
+resolver: lts-18.28
 
 # Local packages, usually specified by relative directory name
 packages:


### PR DESCRIPTION
This seems to rather make the compact output have less newline commas: addressing #84.

eg 
```
    ( "request"
    , ValueArray
        [ ValueString "git+https://src.fedoraproject.org/rpms/rpmbuild-order.git#6a9f3fce18040a2020d37707abb82445e1884e69"
        , ValueString "f37-build-side-54239"
        , ValueStruct
            [
                ( "fail_fast", ValueBool True )
            ,
                ( "wait_builds", ValueArray [] )
            ,
                ( "custom_user_metadata", ValueStruct [] ) ] ] )
,
    ( "result"
    , ValueStruct
        [
            ( "faultCode", ValueInt 1000 )
        ,
            ( "faultString"
            , ValueString "bad filename: A-1-1.fc37.buildreqs.nosrc.rpm (expected A-1-1.fc37.src.rpm)" ) ] )
,
    ( "start_time", ValueString "2022-05-31 02:27:37.208059+00:00" )
```
becomes
```
    ( "request", ValueArray
        [ ValueString "git+https://src.fedoraproject.org/rpms/rpmbuild-order.git#6a9f3fce18040a2020d37707abb82445e1884e69", ValueString "f37-build-side-54239", ValueStruct
            [
                ( "fail_fast", ValueBool True ),
                ( "wait_builds", ValueArray [] ),
                ( "custom_user_metadata", ValueStruct [] ) ] ] ),
    ( "result", ValueStruct
        [
            ( "faultCode", ValueInt 1000 ),
            ( "faultString", ValueString "bad filename: A-1-1.fc37.buildreqs.nosrc.rpm (expected A-1-1.fc37.src.rpm)" ) ] ),
    ( "start_time", ValueString "2022-05-31 02:27:37.208059+00:00" ),
```