### PR TITLE
Add `cabal.project.local` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ cabal.sandbox.config
 *.eventlog
 .stack-work/
 web/result
+cabal.project.local


### PR DESCRIPTION
This file, obtained by running `cabal configure`, is designed not to be checked in.