### PR TITLE
fix: pTraceShowWith should not call show twice

### DIFF
--- a/src/Debug/Pretty/Simple.hs
+++ b/src/Debug/Pretty/Simple.hs
@@ -290,7 +290,7 @@ pTraceWith f a = pTrace (f a) a
 -- @since ?
 {-# WARNING pTraceShowWith "'pTraceShowWith' remains in code" #-}
 pTraceShowWith :: Show b => (a -> b) -> a -> a
-pTraceShowWith f = (show . f) >>= pTraceShow
+pTraceShowWith f = pTraceWith (show . f)
 
 ------------------------------------------
 -- Helpers


### PR DESCRIPTION
## Changes
- fix: `pTraceShowWith` should `pTraceWith` instead of `pTraceShow` since calling `pTraceShow` after `show` would make the shown result  double-quoted